### PR TITLE
Fix revealAnswers initialization order

### DIFF
--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -150,6 +150,48 @@ const MatchPage = () => {
     setSelectedChoice(null);
   }, [match?.current_question_index]);
 
+  const revealAnswers = useCallback(async () => {
+    if (!match || !currentQuestion) return;
+
+    try {
+      await startPhase(match.id, 'round_end');
+
+      for (const answer of answers) {
+        const isCorrect = answer.choice_text === currentQuestion.correctAnswer;
+        const points = isCorrect ? 1 : 0;
+
+        const { error: ansErr } = await supabase
+          .from('answers')
+          .update({ is_correct: isCorrect, points })
+          .eq('match_id', match.id)
+          .eq('uid', answer.uid)
+          .eq('question_index', match.current_question_index);
+        if (ansErr) console.error('Answer update error:', ansErr);
+
+        const player = players.find(p => p.uid === answer.uid);
+        const { error: playerErr } = await supabase
+          .from('players')
+          .update({ score: (player?.score || 0) + points, ready: false })
+          .eq('match_id', match.id)
+          .eq('uid', answer.uid);
+        if (playerErr) console.error('Player score update error:', playerErr);
+      }
+
+      for (const p of players) {
+        if (!answers.some(a => a.uid === p.uid)) {
+          const { error: playerErr } = await supabase
+            .from('players')
+            .update({ ready: false })
+            .eq('match_id', match.id)
+            .eq('uid', p.uid);
+          if (playerErr) console.error('Player ready reset error:', playerErr);
+        }
+      }
+    } catch (error) {
+      console.error('Reveal answers error:', error);
+    }
+  }, [match, currentQuestion, answers, players]);
+
   useEffect(() => {
     if (!match || !isHost) return;
 
@@ -247,48 +289,6 @@ const MatchPage = () => {
       console.error('Start error:', error);
     }
   };
-
-  const revealAnswers = useCallback(async () => {
-    if (!match || !currentQuestion) return;
-
-    try {
-      await startPhase(match.id, 'round_end');
-
-      for (const answer of answers) {
-        const isCorrect = answer.choice_text === currentQuestion.correctAnswer;
-        const points = isCorrect ? 1 : 0;
-
-        const { error: ansErr } = await supabase
-          .from('answers')
-          .update({ is_correct: isCorrect, points })
-          .eq('match_id', match.id)
-          .eq('uid', answer.uid)
-          .eq('question_index', match.current_question_index);
-        if (ansErr) console.error('Answer update error:', ansErr);
-
-        const player = players.find(p => p.uid === answer.uid);
-        const { error: playerErr } = await supabase
-          .from('players')
-          .update({ score: (player?.score || 0) + points, ready: false })
-          .eq('match_id', match.id)
-          .eq('uid', answer.uid);
-        if (playerErr) console.error('Player score update error:', playerErr);
-      }
-
-      for (const p of players) {
-        if (!answers.some(a => a.uid === p.uid)) {
-          const { error: playerErr } = await supabase
-            .from('players')
-            .update({ ready: false })
-            .eq('match_id', match.id)
-            .eq('uid', p.uid);
-          if (playerErr) console.error('Player ready reset error:', playerErr);
-        }
-      }
-    } catch (error) {
-      console.error('Reveal answers error:', error);
-    }
-  }, [match, currentQuestion, answers, players]);
 
   const handleAnswer = async (choiceIndex: number) => {
     if (!currentUser || !match || !currentQuestion || hasAnswered) return;


### PR DESCRIPTION
## Summary
- Define `revealAnswers` before useEffects to avoid TDZ runtime errors

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, require() style import forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc957d78e0832d94b2480077731146