### PR TITLE
Prevent duplicate round scoring

### DIFF
--- a/supabase/functions/score-round/index.ts
+++ b/supabase/functions/score-round/index.ts
@@ -78,6 +78,30 @@ Deno.serve(async (req) => {
       throw new Error('Only the host can trigger scoring')
     }
 
+    // Attempt to mark this round as scored; abort if already scored
+    const { data: flagData, error: flagError } = await supabase
+      .from('matches')
+      .update({ round_scored: true })
+      .eq('id', matchId)
+      .eq('current_question_index', questionIndex)
+      .eq('round_scored', false)
+      .select('id')
+
+    if (flagError) {
+      throw new Error(`Failed to set round_scored flag: ${flagError.message}`)
+    }
+
+    if (!flagData || flagData.length === 0) {
+      console.log(`⚠️ Question ${questionIndex} already scored, skipping duplicate scoring`)
+      return new Response(
+        JSON.stringify({ success: true, message: 'Already scored' }),
+        {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 200
+        }
+      )
+    }
+
     // Get all answers for this question with timing data
     const { data: answers, error: answersError } = await supabase
       .from('answers')
@@ -87,18 +111,6 @@ Deno.serve(async (req) => {
 
     if (answersError) {
       throw new Error(`Failed to fetch answers: ${answersError.message}`)
-    }
-
-    // Check if this round has already been scored
-    if (answers && answers.length > 0 && answers[0].is_correct !== null) {
-      console.log(`⚠️ Question ${questionIndex} already scored, skipping duplicate scoring`)
-      return new Response(
-        JSON.stringify({ success: true, message: 'Already scored' }),
-        { 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          status: 200 
-        }
-      )
     }
 
     // Get the correct answer

--- a/supabase_setup.sql
+++ b/supabase_setup.sql
@@ -14,6 +14,7 @@ create table if not exists matches (
   current_question_index integer not null default 0,
   phase_start timestamptz not null default now(),
   timer_seconds integer not null default 30,
+  round_scored boolean not null default false,
   is_public boolean not null default true,
   created_at timestamptz not null default now()
 );
@@ -148,7 +149,8 @@ returns void language sql security definer as $$
   update matches
      set status = p_status,
          phase_start = now(),
-         current_question_index = coalesce(p_qindex, current_question_index)
+         current_question_index = coalesce(p_qindex, current_question_index),
+         round_scored = false
    where id = p_match_id;
 $$;
 


### PR DESCRIPTION
## Summary
- track scoring with a `scoringRef` so only one scoring trigger runs and reset flag when round ends
- add transactional `round_scored` flag in `score-round` function and schema to stop duplicate score updates

## Testing
- `bun run lint` *(fails: existing lint errors in unrelated files)*
- `bunx eslint src/pages/Match.tsx supabase/functions/score-round/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be1bf71d68832d9c6b2fc3ef7bd30e